### PR TITLE
Adding gemm_ex (fp16->fp32) option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+#folders
+extern/
+
+# Editors
+.vscode
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Executables
+*.exe
+*.out
+*.app
+GemmDriver

--- a/GemmDriver.cpp
+++ b/GemmDriver.cpp
@@ -1622,6 +1622,13 @@ int launch_bench(Arguments& arg, std::promise<std::pair<double,double>> promise)
         {
             BenchGemmEx<rocblas_half, rocblas_half, rocblas_half>(arg, std::move(promise));
         }
+        // gemm_ex: fp16->fp32
+        else if(a_type == "f16_r"  && b_type == "f16_r"
+                && c_type == "f32_r" && d_type == "f32_r"
+                && (compute_type == "f32_r" || compute_type == "s"))
+        {
+            BenchGemmEx<rocblas_half, float, float>(arg, std::move(promise));
+        }
         else if(a_type == "f16_r"  && b_type == "f16_r"
                 && c_type == "f16_r" && d_type == "f16_r"
                 && (compute_type == "f32_r" || compute_type == "s"))

--- a/README.md
+++ b/README.md
@@ -13,10 +13,17 @@ Note: A user may choose to point to a local copy of rocblas by using the -r (--r
 Usage 
 ---------------
 Gemm parameters are specified via command line arguments. Here is a brief overview of the required arguments and default values for different initialization types.
-Example
+
+Example 1:
 ```
 $ ./GemmDriver -f gemm -r s --transposeA N --transposeB N -m 128 -n 128 -k 128 --alpha 1 --lda 128 --ldb 128 --beta 0 --ldc 128 -v 1 --initialization rand_broad
 ```
+
+Example 2 for multi-precision:
+```
+./GemmDriver -f gemm_ex --transposeA N --transposeB T -m 4096 -n 4096 -k 1024 --alpha 1 --a_type f16_r --lda 90112 --b_type f16_r --ldb 90112 --beta 1 --c_type f32_r --ldc 90112 --d_type f32_r --ldd 90112 --compute_type f32_r -i 1
+```
+
 The following arguments are the basic parameters for all GEMM launches:
 ```
 -f [ --function ] arg (=gemm)      GEMM function to test. (gemm,

--- a/utility.hpp
+++ b/utility.hpp
@@ -3049,9 +3049,6 @@ void normalizeInputs(rocblas_operation transa,
                       std::vector<T>& b,
                      size_t ldb,
                      rocblas_stride stride_b,
-                      std::vector<T>& c,
-                     size_t ldc,
-                     rocblas_stride stride_c,
                      size_t batch)
 {
     // We divide each element of B by the maximum corresponding element of A such that elem(A * B) <
@@ -3133,8 +3130,7 @@ static void init_broad_range_random_gemm(rocblas_operation transa,
     init_matrix<rocm_random_addable>(b, transb == rocblas_operation_none ? k : n, transb == rocblas_operation_none ? n : k, ldb, stride_b, batch);
     init_matrix<rocm_random_addable>(c, m, n, ldc, stride_c, batch);
 
-    normalizeInputs<T>(
-        transa, transb, m, n, k, a, lda, stride_a, b, ldb, stride_b, c, ldc, stride_c, batch);
+    normalizeInputs<T>(transa, transb, m, n, k, a, lda, stride_a, b, ldb, stride_b, batch);
 }
 
 template <typename T, typename U = T, std::enable_if_t<std::is_same<T, int8_t>{},int> = 0>


### PR DESCRIPTION
This modification allows benchmarking the performance of gemm_ex for the case that A/B are of type fp16_r, C/D are of type fp32_r with a compute_type fp32_r.