### PR TITLE
remove IEEE16/IEEE32 test code

### DIFF
--- a/GemmDriver.cpp
+++ b/GemmDriver.cpp
@@ -735,49 +735,6 @@ void BenchGemmEx(Arguments& arg, std::promise<std::pair<double,double>> promise)
             exit(1);
         }
 
-        if(arg.initialization != rocblas_initialization_file && std::is_same<To, rocblas_half>{} && std::is_same<Tc, float>{})
-        {
-            // half precision IEEE has max and lowest values 65504 and -65504,
-            // float precision IEEE has max and lowest values 3.403e+38 and -3.403e+38
-            // the following will overflow to inf in half arithmetic,
-            // but it will equal zero in float arithmetic   65504 * 2 - 65504 * 2
-            //
-            // set matrix A and matrix B so reduction sum has 65504 * 2 - 65504 * 2
-            //
-            const rocblas_half ieee_half_near_max(65504.0 - 4.0);
-            const rocblas_half positive_two(2.0);
-            const rocblas_half negative_two(-2.0);
-            if(M >= 2 && N >= 2 && K >= 2)
-            {
-                if(transA == rocblas_operation_none)
-                {
-                    hA[0]   = Ti(ieee_half_near_max);
-                    hA[lda] = Ti(ieee_half_near_max);
-                }
-                else
-                {
-                    hA[0] = Ti(ieee_half_near_max);
-                    hA[1] = Ti(ieee_half_near_max);
-                }
-                if(transB == rocblas_operation_none)
-                {
-                    for(int j = 0; j < N; j++)
-                    {
-                        hB[j * ldb]     = j % 2 == 0 ? Ti(positive_two) : Ti(negative_two);
-                        hB[1 + j * ldb] = j % 2 == 0 ? Ti(negative_two) : Ti(positive_two);
-                    }
-                }
-                else
-                {
-                    for(int j = 0; j < N; j++)
-                    {
-                        hB[j]       = j % 2 == 0 ? Ti(positive_two) : Ti(negative_two);
-                        hB[ldb + j] = j % 2 == 0 ? Ti(negative_two) : Ti(positive_two);
-                    }
-                }
-            }
-        }
-
         if(!c_equals_d)
             rocblas_init<To>(hD_1, M, N, ldd);
 


### PR DESCRIPTION
- code to check IEEE16/IEEE32 arithmetic was changing the A and B matrices and it was not expected that these matrices would change
- remove IEEE16/IEEE32 arithmetic check.